### PR TITLE
Fix -Wdeprecated warnings when compiling with C++ >= 17 (ie with inli…

### DIFF
--- a/include/boost/describe/detail/bases.hpp
+++ b/include/boost/describe/detail/bases.hpp
@@ -26,7 +26,9 @@ template<class C, class B> struct base_descriptor
     static constexpr unsigned modifiers = compute_base_modifiers<C, B>();
 };
 
+#ifndef __cpp_inline_variables
 template<class C, class B> constexpr unsigned base_descriptor<C, B>::modifiers;
+#endif
 
 template<class... T> auto base_descriptor_fn_impl( int, T... )
 {

--- a/include/boost/describe/detail/members.hpp
+++ b/include/boost/describe/detail/members.hpp
@@ -35,9 +35,11 @@ template<class D, unsigned M> struct member_descriptor
     static constexpr unsigned modifiers = M | add_static_modifier( D::pointer() ) | add_function_modifier( D::pointer() );
 };
 
+#ifndef __cpp_inline_variables
 template<class D, unsigned M> constexpr decltype(D::pointer()) member_descriptor<D, M>::pointer;
 template<class D, unsigned M> constexpr decltype(D::name()) member_descriptor<D, M>::name;
 template<class D, unsigned M> constexpr unsigned member_descriptor<D, M>::modifiers;
+#endif
 
 template<unsigned M, class... T> auto member_descriptor_fn_impl( int, T... )
 {

--- a/include/boost/describe/enum.hpp
+++ b/include/boost/describe/enum.hpp
@@ -32,9 +32,11 @@ template<class D> struct enum_descriptor
     static constexpr decltype(D::name()) name = D::name();
 };
 
+#ifndef __cpp_inline_variables
 // GCC requires these definitions
 template<class D> constexpr decltype(D::value()) enum_descriptor<D>::value;
 template<class D> constexpr decltype(D::name()) enum_descriptor<D>::name;
+#endif
 
 template<class... T> auto enum_descriptor_fn_impl( int, T... )
 {

--- a/include/boost/describe/members.hpp
+++ b/include/boost/describe/members.hpp
@@ -86,9 +86,11 @@ template<class T, unsigned Bm> struct update_modifiers
     };
 };
 
+#ifndef __cpp_inline_variables
 template<class T, unsigned Bm> template<class D> constexpr decltype(D::pointer) update_modifiers<T, Bm>::fn<D>::pointer;
 template<class T, unsigned Bm> template<class D> constexpr decltype(D::name) update_modifiers<T, Bm>::fn<D>::name;
 template<class T, unsigned Bm> template<class D> constexpr unsigned update_modifiers<T, Bm>::fn<D>::modifiers;
+#endif
 
 template<class D> struct gather_virtual_bases_impl;
 template<class D> using gather_virtual_bases = typename gather_virtual_bases_impl<D>::type;


### PR DESCRIPTION
…ne variables).

Example of warning we get:
```
/data/mwrep/res/osp/Boost/23-0-0-0/include/boost/describe/members.hpp:89:81: error: redundant redeclaration of 'constexpr' static data member 'boost::describe::detail::update_modifiers<T, Bm>::fn<D>::pointer' [-Werror=deprecated]
 89 | template<class T, unsigned Bm> template<class D> constexpr decltype(D::pointer) update_modifiers<T, Bm>::fn<D>::pointer;
    | ^~~~~~~~~~~~~~~~~~~~~~~ /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/describe/members.hpp:83:47: note: previous declaration of 'boost::describe::detail::update_modifiers<T, Bm>::fn<D>::pointer'
 83 | static constexpr decltype(D::pointer) pointer = D::pointer;
    | ^~~~~~~
```